### PR TITLE
Support latest LTS version 1.651.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.0</version>
         <configuration>
           <encoding>UTF-8</encoding>
           <source>1.7</source>
@@ -66,7 +65,6 @@
       </plugin>
       <plugin>
         <artifactId>maven-eclipse-plugin</artifactId>
-        <version>2.9</version>
         <configuration>
           <downloadSources>true</downloadSources>
         </configuration>
@@ -87,7 +85,6 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.11</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>1.609.3</version>
+    <version>2.7</version>
   </parent>
   <artifactId>regression-report-plugin</artifactId>
   <name>Regression Report Plugin</name>
@@ -20,6 +20,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <powermock.version>1.5</powermock.version>
+    <jenkins.version>1.651.1</jenkins.version>
   </properties>
   <scm>
     <connection>scm:git:git://github.com:jenkinsci/regression-report-plugin.git</connection>
@@ -42,8 +43,8 @@
         <version>3.0</version>
         <configuration>
           <encoding>UTF-8</encoding>
-          <source>1.6</source>
-          <target>1.6</target>
+          <source>1.7</source>
+          <target>1.7</target>
         </configuration>
       </plugin>
       <plugin>
@@ -53,7 +54,7 @@
         <configuration>
           <linkXRef>false</linkXRef>
           <sourceEncoding>UTF-8</sourceEncoding>
-          <targetJdk>1.6</targetJdk>
+          <targetJdk>1.7</targetJdk>
           <rulesets>
             <ruleset>/rulesets/basic.xml</ruleset>
             <ruleset>/rulesets/braces.xml</ruleset>

--- a/src/main/java/jp/skypencil/jenkins/regression/ChangeSetToAuthor.java
+++ b/src/main/java/jp/skypencil/jenkins/regression/ChangeSetToAuthor.java
@@ -1,6 +1,9 @@
 package jp.skypencil.jenkins.regression;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+
+import javax.annotation.Nonnull;
+
 import hudson.model.User;
 import hudson.scm.ChangeLogSet.Entry;
 
@@ -9,7 +12,7 @@ import com.google.common.base.Function;
 final class ChangeSetToAuthor implements Function<Entry, User> {
 
     @Override
-    public User apply(Entry from) {
+    public User apply(@Nonnull Entry from) {
         checkNotNull(from);
         return from.getAuthor();
     }

--- a/src/main/java/jp/skypencil/jenkins/regression/RegressionReportNotifier.java
+++ b/src/main/java/jp/skypencil/jenkins/regression/RegressionReportNotifier.java
@@ -1,23 +1,6 @@
 package jp.skypencil.jenkins.regression;
 
 import static com.google.common.collect.Iterables.transform;
-import hudson.Extension;
-import hudson.Launcher;
-import hudson.Util;
-import hudson.console.AnnotatedLargeText;
-import hudson.model.BuildListener;
-import hudson.model.Result;
-import hudson.model.AbstractBuild;
-import hudson.model.AbstractProject;
-import hudson.model.User;
-import hudson.tasks.BuildStepDescriptor;
-import hudson.tasks.BuildStepMonitor;
-import hudson.tasks.Notifier;
-import hudson.tasks.Publisher;
-import hudson.tasks.Mailer;
-import hudson.tasks.junit.CaseResult;
-import hudson.tasks.test.AbstractTestResultAction;
-import hudson.tasks.test.TestResult;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -29,7 +12,6 @@ import java.util.StringTokenizer;
 
 import javax.activation.DataHandler;
 import javax.activation.DataSource;
-import javax.activation.FileDataSource;
 import javax.mail.Address;
 import javax.mail.BodyPart;
 import javax.mail.Message.RecipientType;
@@ -44,15 +26,31 @@ import javax.mail.internet.MimeMessage;
 import javax.mail.internet.MimeMultipart;
 import javax.mail.util.ByteArrayDataSource;
 
-import jenkins.model.Jenkins;
-import jenkins.model.JenkinsLocationConfiguration;
-
 import org.kohsuke.stapler.DataBoundConstructor;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
+
+import hudson.Extension;
+import hudson.Launcher;
+import hudson.Util;
+import hudson.model.AbstractBuild;
+import hudson.model.AbstractProject;
+import hudson.model.BuildListener;
+import hudson.model.Result;
+import hudson.model.User;
+import hudson.tasks.BuildStepDescriptor;
+import hudson.tasks.BuildStepMonitor;
+import hudson.tasks.Mailer;
+import hudson.tasks.Notifier;
+import hudson.tasks.Publisher;
+import hudson.tasks.junit.CaseResult;
+import hudson.tasks.test.AbstractTestResultAction;
+import hudson.tasks.test.TestResult;
+import jenkins.model.Jenkins;
+import jenkins.model.JenkinsLocationConfiguration;
 
 /**
  * @version 1.0
@@ -177,11 +175,12 @@ public final class RegressionReportNotifier extends Notifier {
         String rootUrl = "";
         Session session = null;
         InternetAddress adminAddress = null;
-        if (Jenkins.getInstance() != null) {
-            rootUrl = Jenkins.getInstance().getRootUrl();
+        Jenkins jenkins = Jenkins.getInstance();
+        JenkinsLocationConfiguration configuration = JenkinsLocationConfiguration.get();
+        if (jenkins != null && configuration != null) {
+            rootUrl = jenkins.getRootUrl();
             session = Mailer.descriptor().createSession();
-            adminAddress = new InternetAddress(
-                    JenkinsLocationConfiguration.get().getAdminAddress());
+            adminAddress = new InternetAddress(configuration.getAdminAddress());
         }
         builder.append(Util.encode(rootUrl));
         builder.append(Util.encode(build.getUrl()));

--- a/src/main/java/jp/skypencil/jenkins/regression/UserToAddr.java
+++ b/src/main/java/jp/skypencil/jenkins/regression/UserToAddr.java
@@ -2,6 +2,7 @@ package jp.skypencil.jenkins.regression;
 
 import java.io.PrintStream;
 
+import javax.annotation.Nonnull;
 import javax.mail.Address;
 import javax.mail.internet.AddressException;
 import javax.mail.internet.InternetAddress;
@@ -25,7 +26,7 @@ final class UserToAddr implements Function<User, Address> {
     }
 
     @Override
-    public Address apply(User user) {
+    public Address apply(@Nonnull User user) {
         Mailer.UserProperty mailProperty = user.getProperty(Mailer.UserProperty.class);
         if (mailProperty == null) {
             return idToAddr.apply(user.getId());

--- a/src/main/resources/index.jelly
+++ b/src/main/resources/index.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <!--
   This view is used to render the installed plugins page.
 -->

--- a/src/main/resources/jp/skypencil/jenkins/regression/RegressionReportNotifier/config.jelly
+++ b/src/main/resources/jp/skypencil/jenkins/regression/RegressionReportNotifier/config.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <f:entry field="recipients" title="${%Recipients}">
     <f:textbox />

--- a/src/test/java/jp/skypencil/jenkins/regression/RegressionReportConfigTest.java
+++ b/src/test/java/jp/skypencil/jenkins/regression/RegressionReportConfigTest.java
@@ -51,7 +51,7 @@ public class RegressionReportConfigTest {
                     + "/configure");
             HtmlForm form = configPage.getFormByName("config");
             form.getInputByName(NAME_CHECKBOX).setChecked(isEnabled);
-            form.submit(last(form.getHtmlElementsByTagName("button")));
+            last(form.getHtmlElementsByTagName("button")).click();
 
             configPage = new WebClient().getPage("job/" + JOB_NAME + "/configure");
             form = configPage.getFormByName("config");

--- a/src/test/java/jp/skypencil/jenkins/regression/RegressionReportConfigTest.java
+++ b/src/test/java/jp/skypencil/jenkins/regression/RegressionReportConfigTest.java
@@ -46,14 +46,15 @@ public class RegressionReportConfigTest {
             IOException, SAXException {
         FreeStyleProject project = jenkins.createFreeStyleProject(JOB_NAME);
 
+        final WebClient client = new WebClient();
         try {
-            HtmlPage configPage = new WebClient().getPage("job/" + JOB_NAME
+            HtmlPage configPage = client.getPage("job/" + JOB_NAME
                     + "/configure");
             HtmlForm form = configPage.getFormByName("config");
             form.getInputByName(NAME_CHECKBOX).setChecked(isEnabled);
             last(form.getHtmlElementsByTagName("button")).click();
 
-            configPage = new WebClient().getPage("job/" + JOB_NAME + "/configure");
+            configPage = client.getPage("job/" + JOB_NAME + "/configure");
             form = configPage.getFormByName("config");
             HtmlInput checkbox = form.getInputByName(NAME_CHECKBOX);
             assertThat(checkbox.isChecked(), is(isEnabled));
@@ -63,6 +64,7 @@ public class RegressionReportConfigTest {
             } catch (InterruptedException ignore) {
                 ignore.printStackTrace();
             }
+            client.close();
         }
     }
 

--- a/src/test/java/jp/skypencil/jenkins/regression/RegressionReportNotifierTest.java
+++ b/src/test/java/jp/skypencil/jenkins/regression/RegressionReportNotifierTest.java
@@ -1,21 +1,14 @@
 package jp.skypencil.jenkins.regression;
 
+
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.junit.Assert.assertThat;
-import static org.powermock.api.mockito.PowerMockito.doReturn;
-import static org.powermock.api.mockito.PowerMockito.mock;
-import hudson.Launcher;
-import hudson.console.AnnotatedLargeText;
-import hudson.model.BuildListener;
-import hudson.model.Result;
-import hudson.model.AbstractBuild;
-import hudson.model.User;
-import hudson.tasks.junit.CaseResult;
-import hudson.tasks.junit.CaseResult.Status;
-import hudson.tasks.test.AbstractTestResultAction;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
 
 import java.io.File;
 import java.io.IOException;
@@ -32,19 +25,31 @@ import javax.mail.internet.MimeBodyPart;
 import javax.mail.internet.MimeMessage;
 
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
+import org.jvnet.hudson.test.JenkinsRule;
 
 import com.google.common.collect.Lists;
 
-@RunWith(PowerMockRunner.class)
-@PrepareForTest(CaseResult.class)
+import hudson.Launcher;
+import hudson.console.AnnotatedLargeText;
+import hudson.model.AbstractBuild;
+import hudson.model.BuildListener;
+import hudson.model.Result;
+import hudson.model.User;
+import hudson.tasks.Mailer;
+import hudson.tasks.junit.CaseResult;
+import hudson.tasks.junit.CaseResult.Status;
+import hudson.tasks.test.AbstractTestResultAction;
+import jenkins.model.JenkinsLocationConfiguration;
+
 public class RegressionReportNotifierTest {
     private BuildListener listener;
     private Launcher launcher;
     private AbstractBuild<?, ?> build;
+
+    @Rule
+    public JenkinsRule rule = new JenkinsRule();
 
     @Before
     public void setUp() throws Exception {
@@ -54,6 +59,10 @@ public class RegressionReportNotifierTest {
         PrintStream logger = mock(PrintStream.class);
         doReturn("").when(build).getUrl();
         doReturn(logger).when(listener).getLogger();
+
+        // set administrator's address to avoid NPE
+        JenkinsLocationConfiguration configuration = JenkinsLocationConfiguration.get();
+        configuration.setAdminAddress("admin@address.com");
     }
 
     @Test
@@ -108,6 +117,8 @@ public class RegressionReportNotifierTest {
         doReturn(Result.FAILURE).when(build).getResult();
         User culprit = mock(User.class);
         doReturn("culprit").when(culprit).getId();
+        doReturn(new Mailer.UserProperty("culprit@mail.com")).when(culprit)
+                .getProperty(eq(Mailer.UserProperty.class));
         doReturn(new ChangeLogSetMock(build).withChangeBy(culprit)).when(build)
                 .getChangeSet();
 

--- a/src/test/java/jp/skypencil/jenkins/regression/RegressionReportNotifierTest.java
+++ b/src/test/java/jp/skypencil/jenkins/regression/RegressionReportNotifierTest.java
@@ -122,7 +122,7 @@ public class RegressionReportNotifierTest {
         makeRegression();
 
         File f = new File(getClass().getResource("/log").getPath());
-        AnnotatedLargeText text = new AnnotatedLargeText(f, Charset.defaultCharset(), false, build);
+        AnnotatedLargeText<?> text = new AnnotatedLargeText<>(f, Charset.defaultCharset(), false, build);
         doReturn(text).when(build).getLogText();
         doReturn(f.getAbsoluteFile().getParentFile()).when(build).getRootDir();
 


### PR DESCRIPTION
To prepare to support Jenkins 2.0, change parent pom to support the latest LTS version.
This change will be released as version 1.6.
